### PR TITLE
Added syntax highlighting for go.mod and go.sum

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ plugin offers, use vim-go instead. I made this plugin for personal use as I like
 
 Only a subset of features is available from the original vim-go plugin.
 
+### Syntax highlighting
+
+Highlighting for `go.mod` and `go.sum`
+
 ### Coverage
 
 ```

--- a/plugin/vim-go-utils.vim
+++ b/plugin/vim-go-utils.vim
@@ -7,4 +7,8 @@ if exists('g:loaded_vim_go_utils')
 endif
 let g:loaded_vim_go_utils = 1
 
+" Set syntax highlighting
+au BufRead,BufNewFile go.mod set syntax=gomod
+au BufRead,BufNewFile go.sum set syntax=gosum
+
 " Nothing to do here as of yet!

--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -1,0 +1,92 @@
+" gomod.vim: Vim syntax file for go.mod file
+"
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax case match
+
+" match keywords
+syntax keyword gomodModule  module
+syntax keyword gomodGo      go      contained
+syntax keyword gomodRequire require
+syntax keyword gomodExclude exclude
+syntax keyword gomodReplace replace
+
+" require, exclude, replace, and go can be also grouped into block
+syntax region gomodRequire start='require (' end=')' transparent contains=gomodRequire,gomodVersion
+syntax region gomodExclude start='exclude (' end=')' transparent contains=gomodExclude,gomodVersion
+syntax region gomodReplace start='replace (' end=')' transparent contains=gomodReplace,gomodVersion
+syntax match  gomodGo            '^go .*$'           transparent contains=gomodGo,gomodGoVersion
+
+" set highlights
+highlight default link gomodModule  Keyword
+highlight default link gomodGo      Keyword
+highlight default link gomodRequire Keyword
+highlight default link gomodExclude Keyword
+highlight default link gomodReplace Keyword
+
+" comments are always in form of // ...
+syntax region gomodComment  start="//" end="$" contains=@Spell
+highlight default link gomodComment Comment
+
+" make sure quoted import paths are higlighted
+syntax region gomodString start=+"+ skip=+\\\\\|\\"+ end=+"+ 
+highlight default link gomodString  String 
+
+" replace operator is in the form of '=>'
+syntax match gomodReplaceOperator "\v\=\>"
+highlight default link gomodReplaceOperator Operator
+
+" match go versions
+syntax match gomodGoVersion "1\.\d\+" contained
+highlight default link gomodGoVersion Identifier
+
+
+" highlight versions:
+"  * vX.Y.Z-pre
+"  * vX.Y.Z
+"  * vX.0.0-yyyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.(Z+1)-0.yyyymmddhhss-abcdefabcdef
+"  see https://godoc.org/golang.org/x/tools/internal/semver for more
+"  information about how semantic versions are parsed and
+"  https://golang.org/cmd/go/ for how pseudo-versions and +incompatible
+"  are applied.
+
+
+" match vX.Y.Z and their prereleases
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?"
+"                          ^--- version ---^^------------ pre-release  ---------------------^^--------------- metadata ---------------------^
+"   	                     ^--------------------------------------- semantic version -------------------------------------------------------^
+
+" match pseudo versions
+" without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion  "v\d\+\.0\.0-\d\{14\}-\x\+"
+" when most recent version before target is a pre-release
+syntax match gomodVersion  "v\d\+\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--- ------ pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^------------------------------------- semantic version --------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--------------- metadata ---------------------^
+
+" match incompatible vX.Y.Z and their prereleases
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?+incompatible"
+"                          ^------- version -------^^------------- pre-release ---------------------^^--------------- metadata ---------------------^
+"               	         ^------------------------------------------- semantic version -----------------------------------------------------------^
+
+" match incompatible pseudo versions
+" incompatible without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion "v[2-9]\{1}\d*\.0\.0-\d\{14\}-\x\++incompatible"
+" when most recent version before target is a pre-release
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------- pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^---------------------------------------- semantic version ------------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------------- metadata ---------------------^
+highlight default link gomodVersion Identifier
+
+let b:current_syntax = "gomod"

--- a/syntax/gosum.vim
+++ b/syntax/gosum.vim
@@ -1,0 +1,55 @@
+" gosum.vim: Vim syntax file for go.sum file
+"
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syntax case match
+
+" highlight versions:
+"  * vX.Y.Z-pre
+"  * vX.Y.Z
+"  * vX.0.0-yyyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.(Z+1)-0.yyyymmddhhss-abcdefabcdef
+"  see https://godoc.org/golang.org/x/tools/internal/semver for more
+"  information about how semantic versions are parsed and
+"  https://golang.org/cmd/go/ for how pseudo-versions and +incompatible
+"  are applied.
+
+
+" match vX.Y.Z and their prereleases
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?"
+"                          ^--- version ---^^------------ pre-release  ---------------------^^--------------- metadata ---------------------^
+"   	                     ^--------------------------------------- semantic version -------------------------------------------------------^
+
+" match pseudo versions
+" without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion  "v\d\+\.0\.0-\d\{14\}-\x\+"
+" when most recent version before target is a pre-release
+syntax match gomodVersion  "v\d\+\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--- ------ pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^------------------------------------- semantic version --------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--------------- metadata ---------------------^
+
+" match incompatible vX.Y.Z and their prereleases
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?+incompatible"
+"                          ^------- version -------^^------------- pre-release ---------------------^^--------------- metadata ---------------------^
+"               	         ^------------------------------------------- semantic version -----------------------------------------------------------^
+
+" match incompatible pseudo versions
+" incompatible without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion "v[2-9]\{1}\d*\.0\.0-\d\{14\}-\x\++incompatible"
+" when most recent version before target is a pre-release
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------- pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^---------------------------------------- semantic version ------------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------------- metadata ---------------------^
+highlight default link gomodVersion Identifier
+
+let b:current_syntax = "gomod"


### PR DESCRIPTION
Copied syntax highlighting for `go.sum` and `go.sum` from the `vim-go` plugin.